### PR TITLE
Fix version file URL property

### DIFF
--- a/GameData/CommunityRealAgencyPack/CommunityRealAgencyPack.version
+++ b/GameData/CommunityRealAgencyPack/CommunityRealAgencyPack.version
@@ -1,6 +1,6 @@
 {
   "NAME": "Community Real Agency Pack",
-  "URL": "https://raw.githubusercontent.com/h0yer/CommunityRealAgencyPack/master/CommunityRealAgencyPack/GameData/CommunityRealAgencyPack/CommunityRealAgencyPack.version",
+  "URL": "https://github.com/h0yer/CommunityRealAgencyPack/raw/master/GameData/CommunityRealAgencyPack/CommunityRealAgencyPack.version",
   "VERSION": {
     "MAJOR": 1,
     "MINOR": 1,


### PR DESCRIPTION
The current version file's URL property is a 404.

https://raw.githubusercontent.com/h0yer/CommunityRealAgencyPack/master/CommunityRealAgencyPack/GameData/CommunityRealAgencyPack/CommunityRealAgencyPack.version

This pull request fixes it. This is useful for updating compatibility after release.

Tagging @h0yer because not everyone has GitHub notifications enabled for pull requests.