### PR TITLE
Fix version file URL property

### DIFF
--- a/GameData/CommunityRealAgencyPack/CommunityRealAgencyPack.version
+++ b/GameData/CommunityRealAgencyPack/CommunityRealAgencyPack.version
@@ -1,6 +1,6 @@
 {
   "NAME": "Community Real Agency Pack",
-  "URL": "https://raw.githubusercontent.com/h0yer/CommunityRealAgencyPack/master/CommunityRealAgencyPack/GameData/CommunityRealAgencyPack/CommunityRealAgencyPack.version",
+  "URL": "https://github.com/h0yer/CommunityRealAgencyPack/raw/master/GameData/CommunityRealAgencyPack/CommunityRealAgencyPack.version",
   "VERSION": {
     "MAJOR": 1,
     "MINOR": 1,


### PR DESCRIPTION
The version file's URL property wasn't a valid link.
Now it is.